### PR TITLE
fix : vue router beforeEnter

### DIFF
--- a/enjoytrip_vue/src/router/index.js
+++ b/enjoytrip_vue/src/router/index.js
@@ -141,7 +141,7 @@ function checkLoginUser(to, from) {
   const isLogin = false;
   if (!isLogin) {
     console.log("로그인이 필요합니다");
-    return { name: "auth" };
+    return { name: "auth-login" };
   }
 }
 


### PR DESCRIPTION
fix : vue router beforeEnter
beforeEnter is a per route guard, it doesn't apply for children.
beforeEnter : return { name: "auth" }; => return { name: "auth-login" };